### PR TITLE
Fix nullref exception thrown when tether settings are applied before player avatar loads

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -39,7 +39,6 @@ namespace NoOutlines
             MelonLogger.Msg("Initialized!");
         }
 
-
         // Skip over initial loading of (buildIndex, sceneName): [(0, "app"), (1, "ui")]
         public override void OnSceneWasLoaded(int buildIndex, string sceneName)
         {
@@ -70,7 +69,6 @@ namespace NoOutlines
                 ApplyOutlineVisibilitySettings();
             }
 
-            
             // This might still throw an error if player is chaanging settings on world join and before their avatar loads
             MelonCoroutines.Start(WaitUntilPlayerIsLoadedToApplyTetherSettings()); // Replaced with hook to OnAvatarInstantiated
         }

--- a/NoOutlines.csproj
+++ b/NoOutlines.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\UIExpansionKit\UIExpansionKit.csproj" />
+      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     </ItemGroup>
 
     <ItemGroup>
@@ -26,6 +26,23 @@
         <SpecificVersion>false</SpecificVersion>
         <Private>false</Private>
         <HintPath>$(MsBuildThisFileDirectory)\..\Libs\Assembly-CSharp.dll</HintPath>
+      </Reference>
+      <Reference Include="UIExpansionKit">
+        <HintPath>..\Output\Release\net472\UIExpansionKit.dll</HintPath>
+      </Reference>
+    </ItemGroup>
+    <ItemGroup>
+      <Reference Include="VRCSDKBase, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <SpecificVersion>false</SpecificVersion>
+        <Private>false</Private>
+        <HintPath>$(MsBuildThisFileDirectory)\..\Libs\VRCSDKBase.dll</HintPath>
+      </Reference>
+    </ItemGroup>
+    <ItemGroup>
+      <Reference Include="VRCCore-Standalone, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <SpecificVersion>false</SpecificVersion>
+        <Private>false</Private>
+        <HintPath>$(MsBuildThisFileDirectory)\..\Libs\VRCCore-Standalone.dll</HintPath>
       </Reference>
     </ItemGroup>
 

--- a/NoOutlines.csproj
+++ b/NoOutlines.csproj
@@ -18,6 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\UIExpansionKit\UIExpansionKit.csproj" />
       <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     </ItemGroup>
 
@@ -26,9 +27,6 @@
         <SpecificVersion>false</SpecificVersion>
         <Private>false</Private>
         <HintPath>$(MsBuildThisFileDirectory)\..\Libs\Assembly-CSharp.dll</HintPath>
-      </Reference>
-      <Reference Include="UIExpansionKit">
-        <HintPath>..\Output\Release\net472\UIExpansionKit.dll</HintPath>
       </Reference>
     </ItemGroup>
     <ItemGroup>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ namespace NoOutlines
     {
         public const string Name = "No Outlines";
         public const string Author = "nonce-twice";
-        public const string Version = "0.1";
+        public const string Version = "0.2";
         public const string DownloadLink = "https://github.com/nonce-twice/NoOutlines";
     }
 }

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ namespace NoOutlines
     {
         public const string Name = "No Outlines";
         public const string Author = "nonce-twice";
-        public const string Version = "0.2";
+        public const string Version = "0.1";
         public const string DownloadLink = "https://github.com/nonce-twice/NoOutlines";
     }
 }

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ Pref_DebugOutput     = false    # Enables debug output in the MelonLoader consol
 
 ### Dependencies
 UIExpansionKit by Knah [link](https://github.com/knah/VRCMods)  
+Newtonsoft.Json
 MelonLoader 0.3.0
 
 ### Build Info
-Place Assembly-CSharp.dll in Libs/  
+Place .dll files from MelonLoader/Managed in Libs/  
 UIExpansionKit is on the same folder level 
 
 #### Example Folder Hierarchy

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Linq;
+using UnhollowerRuntimeLib.XrefScans;
+using System.Reflection;
+using System.Collections;
+using UIExpansionKit.API;
+using MelonLoader;
+using UnityEngine;
+using VRC;
+using Harmony;
+
+namespace NoOutlines
+{
+    // Large parts of this class comes from DynamicBonesSafety mod by Ben
+    // https://github.com/BenjaminZehowlt/DynamicBonesSafety/
+    // Thanks to loukylor for pointing me in the right direction
+    static class Utilities
+    {
+            public static bool checkXref(this MethodBase m, string match)
+            {
+                try
+                {
+                    return XrefScanner.XrefScan(m).Any(
+                        instance => instance.Type == XrefType.Global && instance.ReadAsObject() != null && instance.ReadAsObject().ToString()
+                                       .Equals(match, StringComparison.OrdinalIgnoreCase));
+                }
+                catch { } // ignored
+
+                return false;
+            }
+            public static bool checkXrefMethodPartial(this MethodBase m, string partialMatch)
+            {
+                try
+                {
+                    return XrefScanner.XrefScan(m).Any(
+                        instance => instance.Type == XrefType.Method && instance.TryResolve().Name.Contains(partialMatch));
+                }
+                catch { } // ignored
+
+                return false;
+            }
+
+    }
+}

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -11,11 +11,12 @@ using Harmony;
 
 namespace NoOutlines
 {
-    // Large parts of this class comes from DynamicBonesSafety mod by Ben
+    // All of this class comes from DynamicBonesSafety mod by Ben
     // https://github.com/BenjaminZehowlt/DynamicBonesSafety/
     // Thanks to loukylor for pointing me in the right direction
     static class Utilities
     {
+
             public static bool checkXref(this MethodBase m, string match)
             {
                 try


### PR DESCRIPTION
Added hook to OnAvatarInstantiated
Nullref exception occured when tether settings were applied before player is loaded
Tether settings are now changed when OnAvatarInstantiated is called or when settings menu is closed
